### PR TITLE
Time Scale and Quality of Simulation

### DIFF
--- a/main/src/utils/domain.py
+++ b/main/src/utils/domain.py
@@ -5,6 +5,7 @@ import random
 import platform
 
 from mlagents_envs.environment import UnityEnvironment
+from mlagents_envs.side_channel.engine_configuration_channel import EngineConfigurationChannel
 
 
 class Domain:
@@ -30,10 +31,22 @@ class Domain:
         path = os.path.join(dirname, '../../../environment', folder, f'Crawler{extension}')
         return path, hidden
 
-    def environment(self):
+    def environment(self, time_scale: float = 2, quality_level: float = 1, hide_window: bool = False):
         """
         Generates a new unity ml environment.
+        :param time_scale: The multiplier used for the physics simulation in unity.
+        If a value larger than one is used, time moves more quickly and as such the simulation.
+        :param quality_level: The quality level at which the simulation if performed.
+        A value below one might speed up the simulation at the cost of simulation accuracy.
+        :param hide_window: When set the window is not shown and the training is performed in the backgound.
         :returns: A unity ml environment for the current platform
         """
         path, hidden = self._build_path()
-        return UnityEnvironment(file_name=path, no_graphics=hidden, worker_id=random.randint(0, 65535))
+        if hide_window: hidden = True
+
+        id = random.randint(0, 65535)
+        channel = EngineConfigurationChannel()
+        
+        env = UnityEnvironment(file_name=path, no_graphics=hidden, worker_id=id, side_channels=[channel])
+        channel.set_configuration_parameters(time_scale=time_scale, quality_level=quality_level)
+        return env

--- a/main/src/utils/domain.py
+++ b/main/src/utils/domain.py
@@ -46,7 +46,7 @@ class Domain:
 
         id = random.randint(0, 65535)
         channel = EngineConfigurationChannel()
-        
+
         env = UnityEnvironment(file_name=path, no_graphics=hidden, worker_id=id, side_channels=[channel])
         channel.set_configuration_parameters(time_scale=time_scale, quality_level=quality_level)
         return env

--- a/main/train_crawler_ppo.py
+++ b/main/train_crawler_ppo.py
@@ -14,15 +14,20 @@ from src.utils.wrapper import CrawlerWrapper
 from src.plots.plots import Plots
 
 parser = ArgumentParser(description='The argument mining prediction.')
+
 parser.add_argument('--runs', type=int, help='how many times the training will be performed.', default=1)
 parser.add_argument('--model', type=str, help='The name of the model to load.')
 parser.add_argument('--params', type=str, help='The parameter file for the model.')
 parser.add_argument('--tag', type=str, help='An additional tag for identifying this run.')
 
+parser.add_argument('--speed', type=float, help='Define the speed at which the simulation runs.', default=1)
+parser.add_argument('--quality', type=float, help='Define the quality of the physics simulation', default=1)
+parser.add_argument('--no-window', help='Hides the simulation window.', action='store_true')
+
 args = parser.parse_args()
 
 # create a crawler environment and wrap it in the gym wrapper
-env = Domain().environment()
+env = Domain().environment(args.speed, args.quality, args.no_window)
 env = CrawlerWrapper(env)
 
 # load environment variables


### PR DESCRIPTION
I added the time scale and quality level parameters to the domain class. When calling `environment()` you can use the parameters `time_scale` and `quality_level` to set the values for the simulation. Additionally I added the parameter `hide_window` to disable window rendering.

For the ppo training I also added a commandline argument for each parameter. Use `--speed`, `--quality` and `--no-window` respectively. The latter does not require a value.