### PR TITLE
Added plotting method for performance moving average. 

### DIFF
--- a/main/src/plots/plots.py
+++ b/main/src/plots/plots.py
@@ -2,6 +2,7 @@
 
 import os
 import matplotlib.pyplot as plt
+import numpy as np
 
 from typing import List
 
@@ -37,3 +38,31 @@ class Plots:
         plt.figure()
         plt.plot(values)
         plt.savefig(self.figure_path('performance'))
+
+    def plot_moving_avg_performance(self, values: List[float], window_size: int = 100):
+        """
+        Plots the moving average of the performance of the training run.
+        :param values: The performance of each episode during training.
+        :param window_size: The number of samples to consider for calculating the moving average.
+        """
+        # change plot style
+        # plt.style.use('ggplot')
+
+        # calculate moving average
+        window = np.ones(int(window_size)) / float(window_size)
+        moving_avg = np.convolve(values, window, 'valid')
+
+        plt.figure()
+
+        # plot data
+        plt.plot(values, color='royalblue', alpha=0.3, label='Performance')
+        plt.plot(moving_avg, color='royalblue', label='Moving average of performance')
+
+        # set plot information
+        # plt.title('Moving Average of Performance')
+        plt.xlabel('Episode')
+        plt.ylabel('Performance')
+        plt.legend()
+
+        # save plot
+        plt.savefig(self.figure_path('avg-performance'))

--- a/main/train_crawler_ppo.py
+++ b/main/train_crawler_ppo.py
@@ -72,5 +72,6 @@ for run in range(args.runs):
         with tempfile.TemporaryDirectory() as dir:
             plots = Plots(dir, 'ppo')
             plots.plot_performance(train.performance)
+            plots.plot_moving_avg_performance(train.performance)
 
             mlflow.log_artifacts(dir)

--- a/params/ppo/test_params.json
+++ b/params/ppo/test_params.json
@@ -1,11 +1,11 @@
 {
-    "training_iterations": 10,
+    "training_iterations": 50,
     "params.clip": 0.2,
-    "epochs": 10,
+    "epochs": 1,
     "mini_batch_size": 28,
     "influence_critic": 0.5,
-    "influence_entropy": 0.001,
-    "gamma": 0.9,
+    "influence_entropy": 0.01,
+    "gamma": 0.995,
     "lmbda": 1,
     "trace": 32,
     "learning_rate": 1e-5


### PR DESCRIPTION
I added a plotting method for training performance, which plots the moving average as a smoothed line, while the actual performance is shown lighter in the background. This plot will be created after training is finished and saved to mlflow as an artifact. The factor (window_size) by which the line is smoothed is set to 100 by default.